### PR TITLE
Knowledge: Overview of The Avett Brothers, an American folk rock band.

### DIFF
--- a/knowledge/arts/music/artists/attribution.txt
+++ b/knowledge/arts/music/artists/attribution.txt
@@ -1,0 +1,5 @@
+Title of work: The Avett Bros
+Link to work: https://en.wikipedia.org/wiki/The_Avett_Brothers
+Revision: 1
+License of the work: None
+Creator names: wiki folks

--- a/knowledge/arts/music/artists/qna.yaml
+++ b/knowledge/arts/music/artists/qna.yaml
@@ -1,0 +1,52 @@
+created_by: Misjohns
+version: 3
+domain: Arts
+document_outline: >-
+  Overview of The Avett Brothers, an American folk rock band from North
+  Carolina.
+seed_examples:
+  - context: '1'
+    questions_and_answers:
+      - question: '1'
+        answer: '1'
+      - question: '2'
+        answer: '2'
+      - question: '3'
+        answer: '3'
+  - context: '2'
+    questions_and_answers:
+      - question: '1'
+        answer: '1'
+      - question: '2'
+        answer: '2'
+      - question: '3'
+        answer: '3'
+  - context: '3'
+    questions_and_answers:
+      - question: '1'
+        answer: '1'
+      - question: '2'
+        answer: '2'
+      - question: '3'
+        answer: '3'
+  - context: '4'
+    questions_and_answers:
+      - question: '1'
+        answer: '1'
+      - question: '2'
+        answer: '2'
+      - question: '3'
+        answer: '3'
+  - context: '5'
+    questions_and_answers:
+      - question: '1'
+        answer: '1'
+      - question: '2'
+        answer: '2'
+      - question: '3'
+        answer: '3'
+document:
+  repo: https://en.wikipedia.org/wiki/The_Avett_Brothers
+  commit: asgjvjlv
+  patterns:
+    - the avett brothers


### PR DESCRIPTION
Overview of The Avett Brothers, an American folk rock band from North Carolina.